### PR TITLE
add vendor qcom binaries as dependency

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -18,5 +18,9 @@
   {
     "repository": "android_packages_resources_devicesettings",
     "target_path": "packages/resources/devicesettings"
+  },
+  {
+    "repository": "proprietary_vendor_qcom_binaries",
+    "target_path": "vendor/qcom/binaries"
   }
 ]


### PR DESCRIPTION
- The build requires those binaries. They are specified during "breakfast ferrari". e.i [note1]
- Now do you want to write them here or do you have another convention for this project? I specified them in my local_manifest.xml for the moment. 
- Origin : https://github.com/TheMuppets/proprietary_vendor_qcom_binaries

[note 1]
Otherwise product_config.mk stops : "build/core/product_config.mk:250: *** _nic.PRODUCTS.[[device/xiaomi/ferrari/cm.mk]]: "vendor/qcom/binaries/msm8916/graphics/graphics-vendor.mk" does not exist.  Stop."